### PR TITLE
Fix: update cluster name to hackathon-eks-cluster in workflow and doc…

### DIFF
--- a/.github/workflows/cd-deploy-k8s-to-aws-eks.yaml
+++ b/.github/workflows/cd-deploy-k8s-to-aws-eks.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   AWS_REGION: us-east-1
-  CLUSTER_NAME: fiap-10soat-g21-k8s-cluster
+  CLUSTER_NAME: hackathon-eks-cluster
 
 jobs:
   kubectl:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: ## Print this message
 .PHONY: aws-eks-auth
 aws-eks-auth: ## Authenticate with AWS EKS with the 10soat aws profile
 	@echo  "🟢 Authenticating with AWS EKS..."
-	aws eks update-kubeconfig --name fiap-10soat-g21-k8s-cluster --profile 10soat
+	aws eks update-kubeconfig --name hackathon-eks-cluster --profile 10soat
 
 .PHONY: k8s-apply
 k8s-apply: ## Apply Kubernetes manifests

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Before deploying, ensure you have:
 
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) (v1.24+)
 - [AWS CLI](https://aws.amazon.com/cli/) configured with appropriate permissions
-- Access to AWS EKS cluster: `fiap-10soat-g21-k8s-cluster`
+- Access to AWS EKS cluster: `hackathon-eks-cluster`
 - [Make](https://www.gnu.org/software/make/) for using the Makefile commands
 
 ### Required AWS Permissions
@@ -301,8 +301,8 @@ kubectl top pods -n hackathon
 
 **Cluster authentication issues**
 - Verify you're using the correct cluster name
-- CI/CD uses: `fiap-10soat-g21-k8s-cluster`
-- Local development uses: `fiap-10soat-g21-k8s-cluster`
+- CI/CD uses: `hackathon-eks-cluster`
+- Local development uses: `hackathon-eks-cluster`
 - Ensure your AWS profile has appropriate permissions
 
 ### Debug Commands


### PR DESCRIPTION
This pull request updates the AWS EKS cluster name throughout the project to ensure consistency for both CI/CD and local development environments. The change affects deployment workflows, documentation, and authentication scripts.

Cluster name update:

* [`.github/workflows/cd-deploy-k8s-to-aws-eks.yaml`](diffhunk://#diff-f051b48c7786186736f9664889827ac6ee90254c0172b878c06e0cd4de55c15aL11-R11): Changed the `CLUSTER_NAME` environment variable from `fiap-10soat-g21-k8s-cluster` to `hackathon-eks-cluster` for CI/CD deployments.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L16-R16): Updated the `aws-eks-auth` target to use the new cluster name for authentication.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R68): Updated references to the EKS cluster name in both the deployment prerequisites and troubleshooting sections to reflect the new cluster name. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R68) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L304-R305)…umentation