### PR TITLE
fix: update job starter service config and validation for Kubernetes …

### DIFF
--- a/.github/workflows/cd-deploy-k8s-to-aws-eks.yaml
+++ b/.github/workflows/cd-deploy-k8s-to-aws-eks.yaml
@@ -43,6 +43,7 @@ jobs:
         run: |
           envsubst < configs/video-service-config.yaml > /tmp/video-service-config.yaml && mv /tmp/video-service-config.yaml configs/video-service-config.yaml
           envsubst < configs/video-manager-config.yaml > /tmp/video-manager-config.yaml && mv /tmp/video-manager-config.yaml configs/video-manager-config.yaml
+          envsubst < configs/job-starter-service-config.yaml > /tmp/job-starter-service-config.yaml && mv /tmp/job-starter-service-config.yaml configs/job-starter-service-config.yaml
           envsubst < configs/secrets.yaml > /tmp/secrets.yaml && mv /tmp/secrets.yaml configs/secrets.yaml
         env:
           DB_USER: ${{ steps.base64_encode.outputs.db_user }}
@@ -75,6 +76,8 @@ jobs:
           echo "Validating services..."
           kubectl apply --dry-run=client -f services/video-service/api/
           kubectl apply --dry-run=client -f services/video-service/worker/
+          kubectl apply --dry-run=client -f services/video-manager/
+          kubectl apply --dry-run=client -f services/job-starter-service/
           echo "Validating ingress..."
           kubectl apply --dry-run=client -f ingress/ingress.yaml
         env:


### PR DESCRIPTION
This pull request updates the Kubernetes deployment workflow to support the new `job-starter-service` and improve validation coverage for services. The main changes ensure that configuration files for the new service are correctly processed and that all relevant services are validated before deployment.

**Support for new service configuration:**

* The workflow now processes the `configs/job-starter-service-config.yaml` file using `envsubst`, ensuring environment variables are substituted before deployment.

**Expanded service validation:**

* Added dry-run validation steps for the `services/job-starter-service/` and `services/video-manager/` directories, in addition to the existing video service API and worker. This helps catch configuration errors earlier in the deployment process.…manifests